### PR TITLE
soong: Add `aapt_version_code` default

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -88,6 +88,26 @@ camera_needs_client_info_lib {
 }
 
 soong_config_module_type {
+    name: "aapt_version_code",
+    module_type: "java_defaults",
+    config_namespace: "octaviGlobalVars",
+    value_variables: ["aapt_version_code"],
+    properties: ["aaptflags"],
+}
+
+aapt_version_code {
+    name: "aapt_version_code_defaults",
+    soong_config_variables: {
+        aapt_version_code: {
+            aaptflags: [
+                "--version-code",
+                "%s",
+            ],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "gralloc_10_usage_bits",
     module_type: "cc_defaults",
     config_namespace: "octaviGlobalVars",

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -28,6 +28,7 @@ $(foreach v,$(EXPORT_TO_SOONG),$(eval $(call addVar,$(v))))
 
 SOONG_CONFIG_NAMESPACES += octaviGlobalVars
 SOONG_CONFIG_octaviGlobalVars += \
+    aapt_version_code \
     additional_gralloc_10_usage_bits \
     disable_bluetooth_le_read_buffer_size_v2 \
     disable_bluetooth_le_set_host_feature \
@@ -65,6 +66,7 @@ SOONG_CONFIG_octaviQcomVars += \
 endif
 
 # Soong bool variables
+SOONG_CONFIG_octaviGlobalVars_aapt_version_code := $(shell date -u +%Y%m%d)
 SOONG_CONFIG_octaviGlobalVars_gralloc_handle_has_reserved_size := $(TARGET_GRALLOC_HANDLE_HAS_RESERVED_SIZE)
 SOONG_CONFIG_octaviGlobalVars_has_memfd_backport := $(TARGET_HAS_MEMFD_BACKPORT)
 SOONG_CONFIG_octaviGlobalVars_needs_camera_boottime := $(TARGET_CAMERA_BOOTTIME_TIMESTAMP)


### PR DESCRIPTION
This appends `--version_code=$(date -u +%Y%m%d)` to aapt flags, which is useful for flushing some caches upon system updates.

Change-Id: I6575b878f09c1c3138e12abc34d39405f51245e7