### PR TITLE
config: Move ringtone, notification and alarm props to common path

### DIFF
--- a/config/common_mobile.mk
+++ b/config/common_mobile.mk
@@ -1,13 +1,6 @@
 # Inherit common mobile Lineage stuff
 $(call inherit-product, vendor/octavi/config/common.mk)
 
-ifneq ($(WITH_GAPPS),true)
-# Default notification/alarm sounds
-PRODUCT_PRODUCT_PROPERTIES += \
-    ro.config.notification_sound=Popcorn.ogg \
-    ro.config.alarm_alert=Bright_morning.ogg
-endif
-
 # AOSP packages
 PRODUCT_PACKAGES += \
     Email \

--- a/config/telephony.mk
+++ b/config/telephony.mk
@@ -11,12 +11,6 @@ PRODUCT_PACKAGES += \
     messaging \
     Stk
 
-ifneq ($(WITH_GAPPS),true)
-# Default ringtone
-PRODUCT_PRODUCT_PROPERTIES += \
-    ro.config.ringtone=The_big_adventure.ogg
-endif
-
 # Tethering - allow without requiring a provisioning app
 # (for devices that check this)
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \


### PR DESCRIPTION
- Moved to vendor/google/pixel/config.mk